### PR TITLE
Fix GitHub release process

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -108,11 +108,9 @@ jobs:
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        '${{ github.ref_name }}'
-        --repo '${{ github.repository }}'
-        --notes ""
+      run: |
+        gh release view '${{ github.ref_name }}' --repo '${{ github.repository }}' || \
+        gh release create '${{ github.ref_name }}' --repo '${{ github.repository }}' --notes ""
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/authsignal/version.py
+++ b/authsignal/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.0.5'
+VERSION = '2.0.6'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "authsignal"
-version = "2.0.5"
+version = "2.0.6"
 description = "Authsignal Python SDK for Passwordless Step Up Authentication"
 authors = ["justinsoong <justinsoong@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
This change checks if a GH release exists, before attempting to create a new release.