### PR TITLE
use v4 artifact action

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -46,7 +46,7 @@ jobs:
           deactivate
 
       - name: Store main distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -66,7 +66,7 @@ jobs:
           python3 -m build
 
       - name: Store test distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions-testing
           path: dist/
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -125,7 +125,7 @@ jobs:
 
     steps:
       - name: Download all the test dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions-testing
           path: dist/


### PR DESCRIPTION
v3 is deprecated and causes the action to fail.