### PR TITLE
Bump version for veriffSessionId support

### DIFF
--- a/authsignal/version.py
+++ b/authsignal/version.py
@@ -1,1 +1,1 @@
-VERSION = "4.2.0"
+VERSION = "4.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "authsignal"
-version = "4.3.0"
+version = "4.4.0"
 description = "Authsignal Python SDK for Passwordless Step Up Authentication"
 authors = ["justinsoong <justinsoong@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- The validate-challenge response now includes `veriff_session_id` when the challenge was a Veriff session.
- Bumps version to `4.4.0` (`version.py` was also out of sync with `pyproject.toml` at `4.2.0`; both updated).